### PR TITLE
Change the order of facebook events

### DIFF
--- a/controllers/fbEvents.js
+++ b/controllers/fbEvents.js
@@ -13,7 +13,6 @@ graph.setAppSecret(process.env.appSecret);
 // events using the graph api.
 router.get('/', (req, res) => {
 
-  const date = new Date('January 1, 2017');
   const url = '/186014001799312/events';
   
   // grab events from cses page

--- a/controllers/fbEvents.js
+++ b/controllers/fbEvents.js
@@ -53,6 +53,7 @@ router.get('/', (req, res) => {
         // Counter to handle the async
         eventCounter++;
         if ( eventCounter === 3 ) {
+          eventArray.reverse();
           res.send(eventArray);
         }
       });

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
   },
   "homepage": "https://github.com/jsdavis/server#readme",
   "dependencies": {
+    "angular": "^1.6.3",
     "body-parser": "^1.17.1",
     "bunyan": "^1.8.8",
-    "express": "^4.15.2",
-    "angular": "^1.6.3",
-    "fbgraph": "^1.4.1",
+    "compression": "^1.6.2",
     "dotenv": "^4.0.0",
+    "express": "^4.15.2",
+    "fbgraph": "^1.4.1",
     "strftime": "^0.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolves #26 

* Change the order of facebook events to chronological from reverse chronological.
* Add compression to package.json (it was missing, causing a missing dependency error).