### PR TITLE
Facebook Group button now links to Facebook Page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -98,7 +98,7 @@
         <h2>UC San Diego</h2>
         <h1>Computer Science &amp; Engineering Society</h1>
         <h4>Connecting UC San Diego's CSE community</h4>
-        <a class="header-btn facebook-btn" href="https://www.facebook.com/groups/ucsdcses/" target="_blank">Facebook Group</a>
+        <a class="header-btn facebook-btn" href="https://www.facebook.com/csesucsd/" target="_blank">Facebook Page</a>
         <a class="header-btn subscribe-btn">Subscribe</a>
       </div>
     </header>
@@ -132,7 +132,7 @@
 
       </div>
     </section>
-    
+
     <!-- EVENTS -->
     <section id="events">
       <div class="section-container container">
@@ -142,7 +142,7 @@
           <div ng-repeat="event in events track by $index">
             <div class="event">
               <div class="event-img-container">
-                <div class="event-img-overlay" 
+                <div class="event-img-overlay"
                 >
                   <h4>{{event.name}}</h4>
                   <img ng-src={{event.cover}}></img>
@@ -169,7 +169,7 @@
             </div>
           </div>
         </div>
-        <a href="https://www.facebook.com/pg/csesucsd/events" 
+        <a href="https://www.facebook.com/pg/csesucsd/events"
            class="events-archive-btn">View Archives</a>'
       </div>
     </section>


### PR DESCRIPTION
We are focusing more on growing our Facebook Page as a means of
interacting with our members, so it is more fitting to link users to
the page rather than the group. Resolves #28 