### PR TITLE
Adding fix to change event section shown by default

### DIFF
--- a/src/app/home/events-section/events-section.component.ts
+++ b/src/app/home/events-section/events-section.component.ts
@@ -17,6 +17,9 @@ export class EventsSectionComponent implements OnInit {
 
   ngOnInit() {
     this.populateEvents();
+    if (upcomingFacebookEvents.length == 0){
+      viewingUpcoming = false;
+    }
   }
 
   populateEvents() {


### PR DESCRIPTION
If there are no upcoming events, the website shows past events by default.